### PR TITLE
Fix PyPI publish job rejecting Metadata-Version 2.5

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,8 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  # Allows re-publishing the current version manually if a release run failed.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -21,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -33,7 +35,10 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      # v1.14.2 — older pins ship a twine too old to read Metadata-Version 2.5
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+        # Attestations require Trusted Publishing; unusable with token auth.
+        attestations: false


### PR DESCRIPTION
## Problem

The `deploy` job in **Upload Python Package** failed on the v0.5.1 release ([run 32071448955](https://github.com/yohanchatelain/significantdigits/actions/runs/32071448955)). The package built fine; the upload step failed:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

`pypa/gh-action-pypi-publish` was pinned to `27b3170` — a **February 2021** commit whose bundled twine predates PEP 794. Current hatchling now emits `Metadata-Version: 2.5`, so the old `twine check` rejected the wheel before uploading.

Nothing in this repo changed; the build backend's metadata version did. That's why v0.5.0 published fine in July but v0.5.1 did not.

## Fix

- Bump the publish action to `dc37677` (**v1.14.2**), which ships `twine==7.0.0` and `packaging==26.2` — the latter's `_VALID_METADATA_VERSIONS` includes `"2.5"`, the exact list that produced the error.
- `attestations: false` — v1.14 defaults it to `true`, but it can't work with API token auth (requires Trusted Publishing) and would warn on every run.
- Add `workflow_dispatch`, so a failed release upload can be re-published without re-tagging (`release`-triggered runs use the workflow file at the tagged commit).
- `actions/checkout@v3` → `v4`, `actions/setup-python@v3` → `v5`, clearing the Node 20 deprecation warnings.

## Verification

Built this tree locally and confirmed end to end:

- The wheel declares `Metadata-Version: 2.5` — the value that failed in CI.
- `twine check` **PASSES** on both wheel and sdist under twine 7.0.0 / packaging 26.3.

Same artifact: fails on the old action, passes on the new one.

## Follow-up after merge

**v0.5.1 is tagged on GitHub but absent from PyPI** (latest there is 0.5.0). Re-running the failed run will not help, since it would use the workflow file at the tagged commit. Once this is on `main`, trigger the workflow manually via `workflow_dispatch` — it builds 0.5.1 from `pyproject.toml` and uploads it.

Worth considering separately: switching to Trusted Publishing would drop the `PYPI_API_TOKEN` secret and enable attestations, but needs configuration on PyPI's side, so it's left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)